### PR TITLE
KLS-435 Swagger auth

### DIFF
--- a/conf/urls.py
+++ b/conf/urls.py
@@ -2,6 +2,8 @@ import directory_healthcheck.views
 
 from django.contrib import admin
 from django.urls import path, re_path, include
+from django.contrib.auth.decorators import login_required
+
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 import company.views
@@ -36,8 +38,8 @@ company_urlpatterns = [
 
 urlpatterns = [
     path('openapi/', SpectacularAPIView.as_view(), name='schema'),
-    path('openapi/ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    path('openapi/ui/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    path('openapi/ui/', login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'), name='swagger-ui'),
+    path('openapi/ui/redoc/', login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'), name='redoc'),
     re_path(r'^admin/', admin.site.urls),
     re_path(
         r'^healthcheck/$',

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -38,13 +38,15 @@ company_urlpatterns = [
 
 urlpatterns = [
     path('openapi/', SpectacularAPIView.as_view(), name='schema'),
-    path('openapi/ui/', 
-         login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'), 
-         name='swagger-ui'
+    path(
+        'openapi/ui/',
+        login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'),
+        name='swagger-ui'
     ),
-    path('openapi/ui/redoc/', 
-         login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'), 
-         name='redoc'
+    path(
+        'openapi/ui/redoc/',
+        login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'),
+        name='redoc'
     ),
     re_path(r'^admin/', admin.site.urls),
     re_path(

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -38,8 +38,14 @@ company_urlpatterns = [
 
 urlpatterns = [
     path('openapi/', SpectacularAPIView.as_view(), name='schema'),
-    path('openapi/ui/', login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'), name='swagger-ui'),
-    path('openapi/ui/redoc/', login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'), name='redoc'),
+    path('openapi/ui/', 
+         login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'), 
+         name='swagger-ui'
+    ),
+    path('openapi/ui/redoc/', 
+         login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'), 
+         name='redoc'
+    ),
     re_path(r'^admin/', admin.site.urls),
     re_path(
         r'^healthcheck/$',

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -4,7 +4,7 @@ pytest
 pytest-cov
 pytest-django
 pytest-sugar
-flake8
+flake8==6.0.0
 requests_mock
 freezegun
 factory-boy

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -104,7 +104,7 @@ factory-boy==2.11.1
     # via -r requirements_test.in
 faker==0.8.15
     # via factory-boy
-flake8==3.5.0
+flake8==6.0.0
     # via -r requirements_test.in
 freezegun==0.3.10
     # via -r requirements_test.in
@@ -120,7 +120,7 @@ jsonschema==4.17.3
     # via drf-spectacular
 kombu==5.2.3
     # via celery
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mohawk==0.3.4
     # via sigauth
@@ -136,11 +136,11 @@ psycopg2==2.8.6
     # via -r requirements.in
 py==1.11.0
     # via -r requirements_test.in
-pycodestyle==2.3.1
+pycodestyle==2.10.0
     # via flake8
 pycparser==2.18
     # via cffi
-pyflakes==1.6.0
+pyflakes==3.0.1
     # via flake8
 pyopenssl==18.0.0
     # via requests


### PR DESCRIPTION
This PR wraps the Swagger UI in a login_required decorator so that a user must have administrator privileges and be logged in before viewing.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-436
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Includes screenshot(s) - ideally before and after, but at least after
<img width="685" alt="Screenshot 2023-05-25 at 11 46 18" src="https://github.com/uktrade/directory-companies-house-search/assets/1638245/a6330b28-86f8-4586-aeff-728f0dce7b65">

<img width="1363" alt="Screenshot 2023-05-25 at 11 46 41" src="https://github.com/uktrade/directory-companies-house-search/assets/1638245/fcf94804-5211-4a25-bfde-af04b0c30c5a">

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
