### PR TITLE
KLS-435 - Put openapi spec behind feature flag

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -156,6 +156,7 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
+FEATURE_OPENAPI_ENABLED = env.bool("FEATURE_OPENAPI_ENABLED", False)
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Companies House Search API',
     'DESCRIPTION': 'Companies House search service - the Department for Business and Trade (DBT)',

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -3,6 +3,7 @@ import directory_healthcheck.views
 from django.contrib import admin
 from django.urls import path, re_path, include
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
@@ -37,17 +38,6 @@ company_urlpatterns = [
 ]
 
 urlpatterns = [
-    path('openapi/', SpectacularAPIView.as_view(), name='schema'),
-    path(
-        'openapi/ui/',
-        login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'),
-        name='swagger-ui'
-    ),
-    path(
-        'openapi/ui/redoc/',
-        login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'),
-        name='redoc'
-    ),
     re_path(r'^admin/', admin.site.urls),
     re_path(
         r'^healthcheck/$',
@@ -63,3 +53,18 @@ urlpatterns = [
         r'^api/', include((company_urlpatterns, 'api'), namespace='api')
     )
 ]
+
+if settings.FEATURE_OPENAPI_ENABLED:
+    urlpatterns += [
+        path('openapi/', SpectacularAPIView.as_view(), name='schema'),
+        path(
+            'openapi/ui/',
+            login_required(SpectacularSwaggerView.as_view(url_name='schema'), login_url='admin:login'),
+            name='swagger-ui'
+        ),
+        path(
+            'openapi/ui/redoc/',
+            login_required(SpectacularRedocView.as_view(url_name='schema'), login_url='admin:login'),
+            name='redoc'
+        ),
+    ]


### PR DESCRIPTION
This PR places the openapi spec URL routes behind a feature flag.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-436
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

Add the following to your local env. file:
FEATURE_OPENAPI_ENABLED=True

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [x] Added all new environment variables to Vault.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
