### PR TITLE
bump urllib3 to 1.26.18

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ django-filter>=23.2.*
 django-celery-beat==2.5.*
 django-redis==5.2.*
 django-pglocks==1.0.4
-Pillow==9.3.0
+Pillow==10.1.0
 whitenoise==6.4.*
 gunicorn==19.5.0
 psycopg2==2.8.* --no-binary psycopg2

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ beautifulsoup4==4.6.0
 sigauth==5.2.*
 directory-healthcheck==3.1.2
 cryptography==41.0.3
-urllib3>=1.26.5
+urllib3==1.26.18
 django-environ==0.4.5
 certifi==2023.7.22
 drf-spectacular==0.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,7 @@ kombu==5.2.3
     # via celery
 mohawk==0.3.4
     # via sigauth
-pillow==9.3.0
+pillow==10.1.0
     # via -r requirements.in
 prompt-toolkit==3.0.19
     # via click-repl

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,7 +152,7 @@ tzdata==2023.3
     # via django-celery-beat
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.18
     # via
     #   -r requirements.in
     #   elasticsearch

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -215,7 +215,7 @@ tzdata==2023.3
     # via django-celery-beat
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.18
     # via
     #   -r requirements.in
     #   elasticsearch

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -123,7 +123,7 @@ mohawk==0.3.4
     # via sigauth
 packaging==23.1
     # via pytest
-pillow==9.3.0
+pillow==10.1.0
     # via -r requirements.in
 pluggy==1.0.0
     # via pytest


### PR DESCRIPTION
Bump urllib3 to 1.26.18 and Pillow to 10.1.0

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1332
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
