### PR TITLE
Bump cryptography to 41.0.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ waitress==2.1.2
 beautifulsoup4==4.6.0
 sigauth==5.2.*
 directory-healthcheck==3.1.2
-cryptography==41.0.4
+cryptography==41.0.7
 urllib3==1.26.18
 django-environ==0.4.5
 certifi==2023.7.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ click-repl==0.2.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via -r requirements.in
 directory-healthcheck==3.1.2
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -49,7 +49,7 @@ coverage[toml]==7.2.3
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via -r requirements.in
 directory-healthcheck==3.1.2
     # via -r requirements.in


### PR DESCRIPTION
Bump cryptography to 41.0.7

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1684
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
